### PR TITLE
Added french translations for 8 names

### DIFF
--- a/names.json
+++ b/names.json
@@ -73,6 +73,7 @@
         "meaning": "Greek for \"Manly or brave\"",
         "translations": {
             "eng": "Andrew",
+            "fra": "André",
             "grk": "Ανδρέας",
             "spa": "André",
             "hin": "एंडी"
@@ -91,6 +92,7 @@
         "name": "Jasper",
         "meaning": "Persian for \"Treasurer\"",
         "translations": {
+            "fra": "Gaspard",
             "jpn":"ジャスパー",
             "per": "یشم",
             "slv": "Jasper",
@@ -102,6 +104,7 @@
         "name": "Emily",
         "meaning": "Latin for \"rival\"",
         "translations": {
+            "fra": "Émilie",
             "jpn":"エミリー",
             "lat": "Aemilia",
             "slv": "Emilija",
@@ -123,8 +126,7 @@
         "translations": {
             "chi": "中文",
             "jpn":"メイ",
-            "heb": "מיי",
-            "hin": "में"
+            "heb": "מיי"
         }
     },
     {
@@ -132,20 +134,19 @@
         "meaning" : "Arabic for \"First\"",
         "translations": {
             "jpn":"アッワル",
-            "arb": "أَوَّل",
-            "hin": "अव्‍वल"
+            "arb": "أَوَّل"
         }
     },
     {
         "name": "Josef",
         "meaning": "Hebrew for \"He will enlarge, God will increase\"",
         "translations": {
+            "fra": "José",
             "ces": "Josef",
             "jpn":"ジョセフ",
             "slv": "Jožef",
             "heb": "יוסף",
-            "arb": "جوزف",
-            "hin": "जोसेफ"
+            "arb": "جوزف"
         }
     },
     {
@@ -165,21 +166,19 @@
         "meaning": "Hebrew for \"son of the south\" or \"son of the right hand\"",
         "translations": {
             "heb": "בנג'מין",
-            "fra": "benjoin",
-            "rus": "Бенджамен",
-            "hin": "बेंजामिन"
+            "rus": "Бенджамен"
         }
     },
     {
         "name": "Lucius", 
         "meaning": "derived from Latin lux \"light\"",
         "translations": {
+            "fra": "Luc",
             "ell": "Λούκιος",
             "ita": "Lucio",
             "pol": "Lucjusz",
             "por": "Lúcio",
-            "spa": "Lucio",
-            "hin": "लुसियस"
+            "spa": "Lucio"
         }
     },
     {
@@ -202,6 +201,7 @@
         "name": "Patrick",
         "meaning": "Irish for \"Noble\"",
         "translations": {
+            "fra": "Patrice",
             "lat": "Patricius",
             "spa": "Patricio"
         }
@@ -217,13 +217,15 @@
         "name": "Matan",
         "meaning": "Hewbrew for \"A present\"",
         "translations": {
-            "heb": "מתן"
+            "heb": "מתן",
+            "fra": "Mattan"
         }      
     },
     {
         "name": "Ian",
         "meaning":  "Scottish for \"God is gracious\"",  
         "translations": {
+            "fra": "Yan"
         }
     },
     {


### PR DESCRIPTION
Added french translation for these names:
 * Andy: André
 * Jasper: Gaspard
 * Emily: Émilie
 * Josef: José
 * Lucius: Luc
 * Patrick: Patrice
 * Matan: Mattan
 * Ian: Yan

Removed translation for Benjamin because "benjoin" is not the translation