### PR TITLE
Add test to not allow 'eng' translations.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -44,7 +44,7 @@ describe('names.json', function () {
                             "patternProperties": {
                                 // this part checks that the language code is lower case
                                 // and only 3 characters
-                                "^[a-z]{3}$": {
+                                "^(?!eng)[a-z]{3}$": {
                                     "type": "string"
                                 }
                             },


### PR DESCRIPTION
Added a negative lookahead assertion to not allow 'eng' translations. Fixes #61 