### PR TITLE
Improve mocha tests (Fixes #146)

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -7,44 +7,37 @@ const iso6393 = require('iso-639-3');
 const files = fs.readdirSync('./collection');
 
 describe('name files', () => {
-    it('should contain valid JSON', done => {
-        (async () => {
-            for (const fileName of files) {
-                try {
-                    const contents = fs.readFileSync('./collection/' + fileName);
-                    JSON.parse(contents);
-                } catch (err) {
-                    done(`Error in name file "${fileName}":\n${err}`);
-                }
+    it('should contain valid JSON', () => {
+        for (const fileName of files) {
+            try {
+                const contents = fs.readFileSync('./collection/' + fileName);
+                JSON.parse(contents);
+            } catch (err) {
+                throw new Error(`Error in name file "${fileName}":\n${err}`);
             }
-
-            done();
-        })();
+        }
     });
 
-    it('should contain a lowercase name, same as the filename', done => {
+    it('should contain a lowercase name, same as the filename', () => {
         for (const fileName of files) {
             const contents = fs.readFileSync('./collection/' + fileName);
             const json = JSON.parse(contents);
             assert.ok(json.name === json.name.toLowerCase(), 'name is not lowercase');
             assert.ok(json.name === path.basename(fileName, '.json'), 'fileName should match the name');
         }
-
-        done();
     });
 
-    it('should not have duplicate names', done => {
+    it('should not have duplicate names', () => {
         const names = [];
 
         for (const fileName of files) {
             const contents = fs.readFileSync('./collection/' + fileName);
-            var json = JSON.parse(contents);
+            const json = JSON.parse(contents);
             names.push(json.name);
         }
 
-        var isDuplicate = (new Set(names).size !== names.length);
+        const isDuplicate = (new Set(names).size !== names.length);
         assert.equal(isDuplicate, false);
-        done();
     });
 
     it('should have ISO-639-3 language codes', () => {
@@ -53,16 +46,16 @@ describe('name files', () => {
             const json = JSON.parse(contents);
 
             for (const languageCode in json.translations) {
-                const lookup = iso6393.find(o => o.iso6393 == languageCode);
+                const lookup = iso6393.find(o => o.iso6393 === languageCode);
 
                 if (!lookup) {
-                    assert.fail(`${languageCode} is not a valid ISO-639-3 language code in ${fileName}`);
+                    throw new Error(`${languageCode} is not a valid ISO-639-3 language code in ${fileName}`);
                 }
             }
         }
     });
 
-    it('should have correct structure', done => {
+    it('should have correct structure', () => {
         const jsonValidator = new Validator();
 
         // create the schema for valid name objects
@@ -105,10 +98,8 @@ describe('name files', () => {
                 // Ensure there are no validation errors
                 assert.equal(validationResult.errors.length, 0);
             } catch (err) {
-                done(`Error in name file "${fileName}":\n${err}`);
+                throw new Error(`Error in name file "${fileName}":\n${err}`);
             }
         }
-
-        done();
     });
 });


### PR DESCRIPTION
* Remove the done callback because it is not necessary in these tests
    * This should fix #146 
* Don't use an async function for the first test; the file read is synchronous, so it's not necessary
* Replace instances of `assert.fail` with `throw new Error` because `assert.fail` expects additional parameters that are not currently being provided
* Replace instances of `var` with const