### PR TITLE
#198 feature: Get translation

### DIFF
--- a/api/routes.js
+++ b/api/routes.js
@@ -20,4 +20,10 @@ router.get('/search/:term', (req, res, next) => {
     .catch(err => res.status(404).send({ err: true, debug: err }));
 });
 
+router.get('/:name/:language', (req, res, next) => {
+  utils.getTranslation(req.params.name, req.params.language)
+    .then(results => res.status(200).send(results).end())
+    .catch(err => res.status(404).send({ err: true, debug: err }));
+});
+
 module.exports = router;

--- a/api/utils.js
+++ b/api/utils.js
@@ -43,6 +43,17 @@ module.exports.searchTerm = (term) => {
     });
 }
 
+module.exports.getTranslation = (name, language) => {
+    return new Promise((resolve, reject) => {
+        db.query(`SELECT value FROM translations WHERE name = ${db.escape(name)} AND language = ${db.escape(language)}`, (err, value, fields) => {
+            if (err) return reject(err);
+            if (!value || !value.length) return reject(`Could not find '${language}' translation for '${name}' in the database`);
+
+            return resolve(value[0]);
+        });
+    });
+}
+
 module.exports.generatePublicObject = (name) => {
     return new Promise((resolve, reject) => {
         db.query(`SELECT * FROM meanings WHERE name = ${db.escape(name)}`, (err, meaning, fields) => {


### PR DESCRIPTION
Get translation (`/:name/:language`) - Should return the translation of `:name` in `:language`

right now the returned format is: 
```json
{
    "value": "mathilde"
}
```
for
```sh
GET http://localhost:3000/matilda/fra
```

let me know if you want to change the returned format