### PR TITLE
Name translation route

### DIFF
--- a/api/routes.js
+++ b/api/routes.js
@@ -20,4 +20,10 @@ router.get('/search/:term', (req, res, next) => {
     .catch(err => res.status(404).send({ err: true, debug: err }));
 });
 
+router.get('/:name/:language', (req, res, next) => {
+  utils.findNameTranslation(req.params.name, req.params.language)
+    .then(result => res.status(200).send(result).end())
+    .catch(err => res.status(404).send({ err: true, debug: err }));
+});
+
 module.exports = router;

--- a/api/utils.js
+++ b/api/utils.js
@@ -43,6 +43,17 @@ module.exports.searchTerm = (term) => {
     });
 }
 
+module.exports.findNameTranslation = (name, language) => {
+  return new Promise((resolve, reject) => {
+    db.query(`SELECT * FROM translations WHERE name = ${db.escape(name)} AND language = ${db.escape(language)} LIMIT 1`, (err, translation, fields) => {
+      if (err) return reject(err);
+      if (!translation || !translation.length) return reject(`Could not find language:'${language}' of name:'${name}' in the database`);
+
+      return resolve(translation[0].value);
+    });
+  });
+}
+
 module.exports.generatePublicObject = (name) => {
     return new Promise((resolve, reject) => {
         db.query(`SELECT * FROM meanings WHERE name = ${db.escape(name)}`, (err, meaning, fields) => {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "name-db is a collection of names in all languages. Our goal is to collect as much data as we can, and to provide an open-source free API for name translations.",
   "scripts": {
     "start": "node ./api/bin/www",
+    "dev": "nodemon ./api/bin/www",
     "test": "mocha"
   },
   "repository": {
@@ -18,6 +19,7 @@
     "fs-extra": "^4.0.2",
     "jsonschema": "^1.2.0",
     "mocha": "^4.0.1",
+    "nodemon": "^1.12.1",
     "path": "^0.12.7"
   },
   "dependencies": {


### PR DESCRIPTION
Added new route to the project: GET /:name/:language
This solves the second item of this issue: #198

This pull request was made before and some changes were requested (#217):
- I feel like this route should only return a string, I don't see the point of returning the name and the language.

- It should also find translations of aliases, for example: http://localhost:3000/david finds dave, which is an alias of david, but http://localhost:3000/david/deu doesn't find the German translation of dave, and I feel like it should.

- As I commented in #198, I'd want the API to be able to recognize both language codes and language names, so I except http://localhost:3000/daniel/Arabic to work as well as http://localhost:3000/daniel/ara

The first one was solved, however the other two weren't.

About the second change requested, I got a bit confused when I read it again. Because aliases don't have translations only the real name, I want to know if a request to /dave/deu should return the translation to `david`

About the third change requested, I want to know were should I get the full name of a language that I only have the short name of it. Looking on the database I found these tables: 'Meanings', 'Translations' and 'Aliases'. But I did not find in any of those the information to look for a relation of languages and their shortnames.