### PR TITLE
improve error messaging in tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -22,8 +22,8 @@ describe('name files', () => {
         for (const fileName of files) {
             const contents = fs.readFileSync('./collection/' + fileName);
             const json = JSON.parse(contents);
-            assert.ok(json.name === json.name.toLowerCase(), 'name property "' + json.name + '" in "' + fileName + '" is not lowercase');
-            assert.ok(json.name === path.basename(fileName, '.json'), 'name property "' + json.name + '" in "' + fileName + '" does not match the file name');
+            assert.ok(json.name === json.name.toLowerCase(), `name property "${json.name}" in "${fileName}" is not lowercase`)
+            assert.ok(json.name === path.basename(fileName, '.json'), `name property "${json.name}" in "${fileName}" does not match the file name`);
         }
     });
 
@@ -38,7 +38,7 @@ describe('name files', () => {
 
         const isDuplicate = (new Set(names).size !== names.length);
         const duplicatedNames = names.filter((name, index) => names.indexOf(name) != index);
-        assert.equal(isDuplicate, false, 'duplicated names are not allowed, names duplicated: ' + duplicatedNames.join(', '));
+        assert.equal(isDuplicate, false, `duplicated names are not allowed, names duplicated: ${[...new Set(duplicatedNames)].join(', ')}`);
     });
 
     it('should have ISO-639-3 language codes', () => {
@@ -118,7 +118,7 @@ describe('Translations', () => {
             const keys = Object.keys(translations)
 
             for (const key of keys) {
-                assert.equal(translations[key], translations[key].toLowerCase(), '"' + translations[key] + '" translation in ' + fileName + ' is not lowercase');
+                assert.equal(translations[key], translations[key].toLowerCase(), `"${translations[key]}" translation in "${fileName}" is not lowercase`);
             }
         }
     })
@@ -134,10 +134,11 @@ describe('Sex', () => {
 
             if (sex != null) {
                 // assert.equal takes three parameters: actual value, expected value, and an optional error message)
-                assert.equal(sexParams.indexOf(sex) !== -1, true, "sex property " + "\"" + sex + "\" in " + fileName + " does not match expected values " + "\"" + "m\"" + " \"f\"" + " or" + " \"u\"");
+                assert.equal(sexParams.indexOf(sex) !== -1, true, `sex property "${sex}" in "${fileName}" does not match expected values "m", "f" or "u"`);
             }
         }
-    });       
+    });  
+         
     it('should be lowercase', () => {
         for (const fileName of files) {
             const contents = fs.readFileSync('./collection/' + fileName);
@@ -145,7 +146,7 @@ describe('Sex', () => {
             const sex = json.sex;
 
             if (sex != null) {
-                assert.equal(sex, sex.toLowerCase(), "sex property " + "\"" + sex + "\" in " + fileName + " is not lowercase");
+                assert.equal(sex, sex.toLowerCase(), `sex property "${sex}" in "${fileName}" is not lowercase`);
             }
         }
     });

--- a/test/test.js
+++ b/test/test.js
@@ -13,7 +13,7 @@ describe('name files', () => {
                 const contents = fs.readFileSync('./collection/' + fileName);
                 JSON.parse(contents);
             } catch (err) {
-                throw new Error(`Error in name file "${fileName}":\n${err}`);
+                throw new Error(`Error in name file "${fileName}": Invalid JSON file \n${err}`);
             }
         }
     });
@@ -22,8 +22,8 @@ describe('name files', () => {
         for (const fileName of files) {
             const contents = fs.readFileSync('./collection/' + fileName);
             const json = JSON.parse(contents);
-            assert.ok(json.name === json.name.toLowerCase(), 'name is not lowercase');
-            assert.ok(json.name === path.basename(fileName, '.json'), 'fileName should match the name');
+            assert.ok(json.name === json.name.toLowerCase(), 'name property "' + json.name + '" in "' + fileName + '" is not lowercase');
+            assert.ok(json.name === path.basename(fileName, '.json'), 'name property "' + json.name + '" in "' + fileName + '" does not match the file name');
         }
     });
 
@@ -37,7 +37,8 @@ describe('name files', () => {
         }
 
         const isDuplicate = (new Set(names).size !== names.length);
-        assert.equal(isDuplicate, false);
+        const duplicatedNames = names.filter((name, index) => names.indexOf(name) != index);
+        assert.equal(isDuplicate, false, 'duplicated names are not allowed, names duplicated: ' + duplicatedNames.join(', '));
     });
 
     it('should have ISO-639-3 language codes', () => {
@@ -49,7 +50,7 @@ describe('name files', () => {
                 const lookup = iso6393.find(o => o.iso6393 === languageCode);
 
                 if (!lookup) {
-                    throw new Error(`${languageCode} is not a valid ISO-639-3 language code in ${fileName}`);
+                    throw new Error(`${languageCode} is not a valid ISO-639-3 language code in "${fileName}"`);
                 }
             }
         }
@@ -116,13 +117,9 @@ describe('Translations', () => {
             const translations = json.translations || {};
             const keys = Object.keys(translations)
 
-            const allLowerCase = keys.reduce(
-                (allLowerCase, key) => allLowerCase && (
-                    translations[key] === translations[key].toLowerCase()
-                ), true
-            );
-
-            assert.equal(allLowerCase, true);
+            for (const key of keys) {
+                assert.equal(translations[key], translations[key].toLowerCase(), '"' + translations[key] + '" translation in ' + fileName + ' is not lowercase');
+            }
         }
     })
 });
@@ -137,7 +134,7 @@ describe('Sex', () => {
 
             if (sex != null) {
                 // assert.equal takes three parameters: actual value, expected value, and an optional error message)
-                assert.equal(sexParams.indexOf(sex) !== -1, true, "\"" + sex + "\"" + " should match " + "\"" + "m\"" + " \"f\"" + " or" + " \"u\"");
+                assert.equal(sexParams.indexOf(sex) !== -1, true, "sex property " + "\"" + sex + "\" in " + fileName + " does not match expected values " + "\"" + "m\"" + " \"f\"" + " or" + " \"u\"");
             }
         }
     });       
@@ -148,7 +145,7 @@ describe('Sex', () => {
             const sex = json.sex;
 
             if (sex != null) {
-                assert.equal(sex, sex.toLowerCase(), "\"" + sex + "\"" + " is not lowercase");
+                assert.equal(sex, sex.toLowerCase(), "sex property " + "\"" + sex + "\" in " + fileName + " is not lowercase");
             }
         }
     });


### PR DESCRIPTION
There has been times I see the tests failing on some of the PRs but when I look at the Travis CI build, it doesn't tell me what file it is that's causing the failure and the reason for it.

So I have updated the tests to output a more meaningful message including the JSON file that's causing the test to fail.